### PR TITLE
Change amount of penalty

### DIFF
--- a/DevQuiz.API/Controllers/QuizController.cs
+++ b/DevQuiz.API/Controllers/QuizController.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 [Route("api/[controller]")]
 public class QuizController(QuizDbContext db, ILogger<QuizController> logger) : ControllerBase
 {
-    private const int WrongAnswerPenaltyMs = 1000; // milliseconds
+    private const int WrongAnswerPenaltyMs = 10000; // milliseconds
 
     [HttpGet("current")]
     [ProducesResponseType(typeof(CurrentQuestionDto), 200)]


### PR DESCRIPTION
Changed penalty from 1 second to 10 seconds by changing the penalty constant.

![chrome_vcoHRy49kE](https://github.com/user-attachments/assets/1fa3b42c-6c6b-408e-b173-525e40f771d8)

Test: 
- Check that the feedback message states 10s penalty
- Check that the penalty counter increments with 10s for each penalty
- Check that the total time equals the elapsed time added with the penalty counter