### PR TITLE
Dynamic update of total questions based on questions in database

### DIFF
--- a/DevQuiz.API/Dtos/SessionStartedDto.cs
+++ b/DevQuiz.API/Dtos/SessionStartedDto.cs
@@ -5,4 +5,7 @@ public class SessionStartedDto
     public bool Success { get; set; }
 
     public string? Message { get; set; }
+
+    public int TotalQuestions { get; set; }
+
 }

--- a/DevQuiz.WebClient/src/lib/api.ts
+++ b/DevQuiz.WebClient/src/lib/api.ts
@@ -38,6 +38,7 @@ export interface StartSessionRequest {
 
 export interface StartSessionResponse {
   success: boolean
+  totalQuestions?: number
   message?: string
 }
 
@@ -113,10 +114,11 @@ class ApiClient {
       body: JSON.stringify({ name, phone, difficulty, avatarUrl }),
     })
 
-    const data = await this.handleResponse<{ success: boolean; message?: string }>(response)
+    const data = await this.handleResponse<{ success: boolean; message?: string; totalQuestions?: number }>(response)
     return {
       success: data.success ?? false,
-      message: data.message
+      message: data.message,
+      totalQuestions: data.totalQuestions
     }
   }
 

--- a/DevQuiz.WebClient/src/stores/session.ts
+++ b/DevQuiz.WebClient/src/stores/session.ts
@@ -8,7 +8,7 @@ export const useSessionStore = defineStore('session', () => {
   const avatar = ref('')
   const hasSession = ref(false)
   const currentQuestionIndex = ref(0)
-  const totalQuestions = ref(5)
+  const totalQuestions = ref(0) // Will be set from API response
   const totalTimeMs = ref<number | null>(null)
 
   const isAuthenticated = computed(() => hasSession.value)
@@ -24,6 +24,10 @@ export const useSessionStore = defineStore('session', () => {
         hasSession.value = true
         currentQuestionIndex.value = 0
         totalTimeMs.value = null
+        
+        if (result.totalQuestions) {
+          totalQuestions.value = result.totalQuestions
+        }
       } else {
         hasSession.value = false
         throw new Error(result.message || 'Failed to start session')


### PR DESCRIPTION
Dynamic update of total questions based on questions in database. 

Implementation: 
- totalQuestions is set to a default value of 0 in SessionStore
- The value of totalQuestions is updated in startSession when the quiz starts
- This value is decided based on the count of rows in the QuizQuestions table with the quizid corresponding to the chosen difficulty in the Quizzes table

Example:

Quizzes table:
<img width="160" height="48" alt="image" src="https://github.com/user-attachments/assets/791ed799-5a26-45dc-b884-211b7513b4a8" />

QuizQuestions table:
<img width="211" height="131" alt="image" src="https://github.com/user-attachments/assets/bbae54c9-6db5-4ca4-b8a7-73e98a5ab92a" />

Quiz experience:
![chrome_9sBbILoJ7t](https://github.com/user-attachments/assets/5d879927-e77f-4dc4-ba71-8666819826df)

Test:
- Check that total number of ducks match the number of questions for the chosen difficulty (either check database directly or just check that the quiz ends after the stated amount of total questions are completed)


