### PR TITLE
Added rule for avatar references always being sent as file paths

### DIFF
--- a/DevQuiz.WebClient/vite.config.ts
+++ b/DevQuiz.WebClient/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         return false
       }
       // Use default behavior for other files (4KB limit)
-      return true
+      return undefined
     },
   },
 })


### PR DESCRIPTION
Have solved the problem with users not being able to choose the feather as avatar. The problem was that svg-files under 4KB (which is the case for only this avatar) are being sent inline, while bigger files are being sent as a file path. When storing the AvatarUrl, it expects a file path, not inline content. Thus, an error rises. My quick-fix was to add a rule for avatar references to always be sent as file paths (SVG files that contain "avatar" or "Avatar"). It's not the most elegant solution, but the best I could find that solves the problem without changing the way we load and store the avatars. Please let me know if you have any suggestions for other ways to solve it!

Here you can see that it works:

![chrome_7s0tLz46Lo](https://github.com/user-attachments/assets/316fccb8-22c4-4c75-87d3-670875460c9f)

<img width="726" height="107" alt="image" src="https://github.com/user-attachments/assets/0ab6616f-aa1e-42c7-8742-18efd65c2bdc" />

Test it yourself by checking that you can actually start the quiz with the feather avatar. Ensure that other avatars work as well.
